### PR TITLE
Do not use anymore the first object for an array

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   // Extends the UdeS ESLint config
-  extends: "eslint-config-udes/node-14",
+  extends: 'eslint-config-udes/node-14',
 
   // Limit ESLint to a specific project
   root: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherby/eleventy-plugin-javascript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An Eleventy plugin that add useful shortcodes to JavaScript template files",
   "keywords": [
     "11ty",
@@ -40,12 +40,12 @@
     "json-stable-stringify": "^1.0.1"
   },
   "devDependencies": {
-    "eslint-config-udes": "^0.4.3",
+    "eslint-config-udes": "^1.0.1",
     "eslint-plugin-json-format": "^2.0.1",
-    "eslint-plugin-markdown": "^1.0.2",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-markdown": "^2.0.0",
+    "eslint-plugin-prettier": "^3.3.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.1.2",
-    "prettier-config-udes": "0.0.6"
+    "prettier": "^2.2.1",
+    "prettier-config-udes": "1.0.0"
   }
 }

--- a/src/javascript-comments.js
+++ b/src/javascript-comments.js
@@ -1,4 +1,4 @@
 module.exports = {
-  startJavaScriptComment: (start = true) => (start ? "/*" : ""),
-  closeJavaScriptComment: (close = true) => (close ? "*/" : ""),
+  startJavaScriptComment: (start = true) => (start ? '/*' : ''),
+  closeJavaScriptComment: (close = true) => (close ? '*/' : ''),
 };

--- a/src/print-javascript.js
+++ b/src/print-javascript.js
@@ -1,9 +1,9 @@
 module.exports = {
   printJavaScriptArray: (array) => {
-    if (!array || !array.length) return "";
+    if (!array || !array.length) return '';
 
     return `printJavaScriptArray
-      ${array.join("\\n")}
+      ${array.join('\\n')}
     `;
   },
 };

--- a/src/to-javascript.js
+++ b/src/to-javascript.js
@@ -1,12 +1,18 @@
-const jsonStableStringify = require("json-stable-stringify");
+const jsonStableStringify = require('json-stable-stringify');
 
 const addPropertyToObject = (object, newObject) => (property) => (newObject[property] = object[property]);
 const stringify = (object) => jsonStableStringify(object, { space: 2 });
 const slice = (string) => string.slice(1, string.length - 1);
 
 const toObject = (properties) => (object) => {
-  const newObject = {};
-  properties.forEach(addPropertyToObject(object, newObject));
+  let newObject = {};
+
+  if (properties) {
+    properties.forEach(addPropertyToObject(object, newObject));
+  } else {
+    newObject = JSON.parse(JSON.stringify(object));
+  }
+
   return newObject;
 };
 
@@ -22,16 +28,16 @@ const toJavaScriptArray = (objects, properties) => {
   return slice(javaScriptArray);
 };
 
-const getProperties = (object, propertiesAsString) => {
-  if (propertiesAsString) return propertiesAsString.split(",");
-  return Object.keys(object);
+const getProperties = (propertiesAsString) => {
+  if (propertiesAsString) return propertiesAsString.split(',');
+  return null;
 };
 
 module.exports = {
   toJavaScript: (object, propertiesAsString) => {
-    if (!object) return "";
+    if (!object) return '';
 
-    const properties = getProperties(object, propertiesAsString);
+    const properties = getProperties(propertiesAsString);
     const toJavaScriptFunction = Array.isArray(object) ? toJavaScriptArray : toJavaScriptObject;
     return `toJavaScript
       ${toJavaScriptFunction(object, properties)}
@@ -39,18 +45,18 @@ module.exports = {
   },
 
   toJavaScriptArray: (objects, propertiesAsString) => {
-    if (!objects || !objects.length) return "";
+    if (!objects || !objects.length) return '';
 
-    const properties = getProperties(objects[0], propertiesAsString);
+    const properties = getProperties(propertiesAsString);
     return `toJavaScriptArray
       ${toJavaScriptArray(objects, properties)}
     `;
   },
 
   toJavaScriptObject: (object, propertiesAsString) => {
-    if (!object) return "";
+    if (!object) return '';
 
-    const properties = getProperties(object, propertiesAsString);
+    const properties = getProperties(propertiesAsString);
     return `toJavaScriptObject
       ${toJavaScriptObject(object, properties)}
     `;


### PR DESCRIPTION
- Update devDependencies
- Fix a bug on the toJavaScriptArray function, as we cannot use the first object to determine all properties to clone...
- Reformat the code